### PR TITLE
Parse multiple statements in the same line

### DIFF
--- a/compile/compile_test.go
+++ b/compile/compile_test.go
@@ -626,7 +626,7 @@ func TestCompileSwitchStmt(t *testing.T) {
 		},
 		{
 			Scenario: "compile switch stmt multiple cases",
-			Code:     "switch 10 { case 10: puts(10) case 20: puts(20) }",
+			Code:     "switch 10 { case 10: puts(10); case 20: puts(20) }",
 			Matches: []Match{
 				expect(bytecode.Push).toHaveOperand(0).toHaveConstant(10),
 				expect(bytecode.Push).toHaveOperand(1).toHaveConstant(10),
@@ -651,7 +651,7 @@ func TestCompileSwitchStmt(t *testing.T) {
 		},
 		{
 			Scenario: "compile switch stmt full",
-			Code:     `switch 10 { case 10: puts(10) case 20: puts(20) default: puts("default") }`,
+			Code:     `switch 10 { case 10: puts(10); case 20: puts(20); default: puts("default") }`,
 			Matches: []Match{
 				expect(bytecode.Push).toHaveOperand(0).toHaveConstant(10),
 				expect(bytecode.Push).toHaveOperand(1).toHaveConstant(10),

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -232,6 +232,10 @@ func TestNextToken(t *testing.T) {
 			Input:        bytes.NewBufferString("super"),
 			ExpectedType: token.Super,
 		},
+		"Semicolon is new line": {
+			Input:        bytes.NewBufferString(";"),
+			ExpectedType: token.NewLine,
+		},
 	}
 
 	for scenario, test := range tests {
@@ -267,6 +271,7 @@ b = "str"
 		{Line: 2, Column: 1, Kind: token.Ident},
 		{Line: 2, Column: 3, Kind: token.Assign},
 		{Line: 2, Column: 5, Kind: token.Int},
+		{Line: 2, Column: 7, Kind: token.NewLine},
 		{Line: 3, Column: 1, Kind: token.Ident},
 		{Line: 3, Column: 3, Kind: token.Assign},
 		{Line: 3, Column: 5, Kind: token.String},

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -648,3 +648,23 @@ func Test_ParseSuperExpr(t *testing.T) {
 		})
 	}
 }
+
+func TestParse_withStmtsInTheSameLine(t *testing.T) {
+	stmts := setupTest(t, "a = 10; b = 20", 2)
+
+	first, ok := stmts[0].(*ast.AssignStmt)
+	if !ok {
+		t.Fatalf("expected ast.AssignStmt, got %T", stmts[0])
+	}
+
+	testIdent(t, first.Left[0], "a")
+	testLit(t, first.Right[0], "10")
+
+	second, ok := stmts[1].(*ast.AssignStmt)
+	if !ok {
+		t.Fatalf("expected ast.AssignStmt, got %T", stmts[1])
+	}
+
+	testIdent(t, second.Left[0], "b")
+	testLit(t, second.Right[0], "20")
+}

--- a/token/type_string.go
+++ b/token/type_string.go
@@ -38,27 +38,28 @@ func _() {
 	_ = x[Star-27]
 	_ = x[Dot-28]
 	_ = x[Colon-29]
-	_ = x[Not-30]
-	_ = x[Arrow-31]
-	_ = x[Comma-32]
-	_ = x[Assign-33]
-	_ = x[Equal-34]
-	_ = x[Less-35]
-	_ = x[LessEqual-36]
-	_ = x[Great-37]
-	_ = x[GreatEqual-38]
-	_ = x[Ident-39]
-	_ = x[LeftParenthesis-40]
-	_ = x[RightParenthesis-41]
-	_ = x[LeftBracket-42]
-	_ = x[RightBracket-43]
-	_ = x[LeftBrace-44]
-	_ = x[RightBrace-45]
+	_ = x[NewLine-30]
+	_ = x[Not-31]
+	_ = x[Arrow-32]
+	_ = x[Comma-33]
+	_ = x[Assign-34]
+	_ = x[Equal-35]
+	_ = x[Less-36]
+	_ = x[LessEqual-37]
+	_ = x[Great-38]
+	_ = x[GreatEqual-39]
+	_ = x[Ident-40]
+	_ = x[LeftParenthesis-41]
+	_ = x[RightParenthesis-42]
+	_ = x[LeftBracket-43]
+	_ = x[RightBracket-44]
+	_ = x[LeftBrace-45]
+	_ = x[RightBrace-46]
 }
 
-const _Type_name = "IllegalEOFifisforswitchcasedefaultinstopnextwhileelsefunnonecatchblockobjectreturnsuperIntFloatStringBool-+/*.:!->Comma===<<=>>=Ident()[]{}"
+const _Type_name = "IllegalEOFifisforswitchcasedefaultinstopnextwhileelsefunnonecatchblockobjectreturnsuperIntFloatStringBool-+/*.:\\n!->Comma===<<=>>=Ident()[]{}"
 
-var _Type_index = [...]uint8{0, 7, 10, 12, 14, 17, 23, 27, 34, 36, 40, 44, 49, 53, 56, 60, 65, 70, 76, 82, 87, 90, 95, 101, 105, 106, 107, 108, 109, 110, 111, 112, 114, 119, 120, 122, 123, 125, 126, 128, 133, 134, 135, 136, 137, 138, 139}
+var _Type_index = [...]uint8{0, 7, 10, 12, 14, 17, 23, 27, 34, 36, 40, 44, 49, 53, 56, 60, 65, 70, 76, 82, 87, 90, 95, 101, 105, 106, 107, 108, 109, 110, 111, 113, 114, 116, 121, 122, 124, 125, 127, 128, 130, 135, 136, 137, 138, 139, 140, 141}
 
 func (i Type) String() string {
 	if i >= Type(len(_Type_index)-1) {

--- a/token/types.go
+++ b/token/types.go
@@ -36,10 +36,11 @@ const (
 	Slash // /
 	Star  // *
 
-	Dot   // .
-	Colon // :
-	Not   // !
-	Arrow // ->
+	Dot     // .
+	Colon   // :
+	NewLine // \n
+	Not     // !
+	Arrow   // ->
 	Comma
 	Assign           // =
 	Equal            // ==


### PR DESCRIPTION
### What?
**Bug:**
We were not able to have multiple statements in the same line.

*Example:*
```
a = 10; puts(a)
```

**Fix:**
Lexer will not ignore a new line token (\n) after reading a
ident, number, string or any closing brace.

Note: Semicolon is considered a new line.

Parse will expect a new line token after parsing any statement.
