### PR TITLE
Fix return statement without value

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -177,7 +177,7 @@ func (e *ExprStmt) String() string {
 
 type ReturnStmt struct {
 	Token *token.Token
-	Expr  Expr
+	Value Expr
 
 	stmt
 }
@@ -185,7 +185,7 @@ type ReturnStmt struct {
 func (r *ReturnStmt) String() string {
 	var buf strings.Builder
 	buf.WriteString("return ")
-	buf.WriteString(r.Expr.String())
+	buf.WriteString(r.Value.String())
 
 	return buf.String()
 }

--- a/compile/compile.go
+++ b/compile/compile.go
@@ -207,10 +207,7 @@ func (c *compiler) compileStmt(stmt ast.Stmt) {
 		c.compileBlock(node, false)
 
 	case *ast.ReturnStmt:
-		c.rewindControlFlow(false)
-		c.compileExpr(node.Expr, true)
-		c.add(bytecode.Return, 0)
-		c.block.hasReturn = true
+		c.compileReturnStmt(node)
 
 	case *ast.StopStmt:
 		c.compileStopStmt(node)
@@ -593,7 +590,12 @@ func (c *compiler) rewindControlFlow(inLoop bool) {
 func (c *compiler) compileReturnStmt(ret *ast.ReturnStmt) {
 	c.rewindControlFlow(false)
 
-	c.compileExpr(ret.Expr, true)
+	if ret.Value != nil {
+		c.compileExpr(ret.Value, true)
+	} else {
+		c.add(bytecode.PushNone, 0)
+	}
+
 	c.add(bytecode.Return, 0)
 	c.block.hasReturn = true
 }

--- a/compile/compile_test.go
+++ b/compile/compile_test.go
@@ -966,3 +966,40 @@ func TestCompileUnaryOperator(t *testing.T) {
 		}
 	}
 }
+
+func TestCompileReturnStmt(t *testing.T) {
+	methMatches := []Match{
+		expect(bytecode.Push).withOperand(0).toHaveConstant(10),
+		expect(bytecode.Return),
+	}
+
+	top := []Match{
+		expect(bytecode.DefineFunction).toDefine("do_stuff", methMatches),
+		expect(bytecode.PushNone),
+		expect(bytecode.Return),
+	}
+
+	meth := compile("fun do_stuff { return 10 }")
+	for i, instr := range meth.Instrs() {
+		top[i].Match(t, instr, meth.Constants())
+	}
+
+}
+
+func TestCompileReturnStmt_withoutValue(t *testing.T) {
+	methMatches := []Match{
+		expect(bytecode.PushNone),
+		expect(bytecode.Return),
+	}
+
+	top := []Match{
+		expect(bytecode.DefineFunction).toDefine("do_stuff", methMatches),
+		expect(bytecode.PushNone),
+		expect(bytecode.Return),
+	}
+
+	meth := compile("fun do_stuff { return }")
+	for i, instr := range meth.Instrs() {
+		top[i].Match(t, instr, meth.Constants())
+	}
+}

--- a/parser/helpers_test.go
+++ b/parser/helpers_test.go
@@ -108,3 +108,24 @@ func testLit(t *testing.T, expr ast.Expr, expectedValue string) {
 		t.Errorf("expected *ast.BasicLit.Value to be %q, got %q", expectedValue, lit.Value)
 	}
 }
+
+func assertFunDecl(t *testing.T, stmt ast.Stmt, name string, params ...string) *ast.FunDecl {
+	t.Helper()
+
+	funDecl, ok := stmt.(*ast.FunDecl)
+	if !ok {
+		t.Fatalf("expected first stmt to be *ast.FunDecl, got %T", stmt)
+	}
+
+	testIdent(t, funDecl.Name, name)
+
+	if len(funDecl.Parameters) != len(params) {
+		t.Fatalf("FunDecl params size is %d, given %d", len(funDecl.Parameters), len(params))
+	}
+
+	for i, got := range funDecl.Parameters {
+		testIdent(t, got, params[i])
+	}
+
+	return funDecl
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -278,10 +278,14 @@ func (p *parser) parseNextStmt() ast.Stmt {
 }
 
 func (p *parser) parseReturnStmt() ast.Stmt {
-	return &ast.ReturnStmt{
-		Token: p.expect(token.Return),
-		Expr:  p.parseExpr(),
+	retToken := p.expect(token.Return)
+
+	var value ast.Expr
+	if p.tok.Type != token.NewLine && p.tok.Type != token.RightBrace {
+		value = p.parseExpr()
 	}
+
+	return &ast.ReturnStmt{Token: retToken, Value: value}
 }
 
 func (p *parser) parseParameterList() (list []*ast.Ident) {


### PR DESCRIPTION
### What?

**Bug:**
We were not able to return a function without a value

*Example:*
```iracema
fun do_stuff {
  return
}
```


This fixes it.
